### PR TITLE
add hashbang to run script using node

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { exec, execSync } from 'child_process';
 import { existsSync, mkdirSync, readFileSync } from 'fs';
 import { copyFile } from 'fs/promises';


### PR DESCRIPTION
this change allows the program to run via `./build.mjs` as is documented in the readme